### PR TITLE
Collision: BA Check + Collision Handler Expansion

### DIFF
--- a/sprint0/Blocks/DungeonPyramidBlock.cs
+++ b/sprint0/Blocks/DungeonPyramidBlock.cs
@@ -22,8 +22,8 @@ namespace sprint0.Blocks
         public Texture2D Texture { get; set; }
         public int Rows { get; set; }
         public int Columns { get; set; }
-        private int XValue { get; set; }
-        private int YValue { get; set; }
+        public int XValue { get; set; }
+        public int YValue { get; set; }
 
 
 
@@ -83,7 +83,7 @@ namespace sprint0.Blocks
         public int yPosition() { return YValue; } // returns Y pos of object
         public int width() { return blockSprite.GetWidth(); } // (i.e.) "how big are you?"
         public int height() { return blockSprite.GetHeight(); } // (i.e.) "how big are you?"
-        public bool isDynamic() { return false; } // does this object move? 
+        public bool isDynamic() { return true; } // does this object move? 
         public bool isUpdateable() { return true; }
         public bool isInPlay() { return true; }
         public bool isDrawable() { return true; }

--- a/sprint0/Collision/CollisionDetector.cs
+++ b/sprint0/Collision/CollisionDetector.cs
@@ -20,6 +20,7 @@ namespace sprint0.Collision
     public static class CollisionDetector
 	{
 		public enum CollisionType { TOP, BOTTOM, LEFT, RIGHT, NONE };
+		
         // Do we need this enum in every Collision Class?
 
         /*

--- a/sprint0/Collision/CollisionHandler.cs
+++ b/sprint0/Collision/CollisionHandler.cs
@@ -48,7 +48,15 @@ namespace sprint0.Collision
             DataRow rowWithDelegates = null;
             foreach (DataRow row in collisionTable.Rows)
             {
+                //AB check.
                 if (row["ObjectA"].Equals(objAType) && row["ObjectB"].Equals(objBType)) {
+                    rowWithDelegates = row;
+                    break;
+                }
+
+                //BA check
+                else if (row["ObjectA"].Equals(objBType) && row["ObjectB"].Equals(objAType))
+                {
                     rowWithDelegates = row;
                     break;
                 }

--- a/sprint0/Collision/CollisionHandler.cs
+++ b/sprint0/Collision/CollisionHandler.cs
@@ -3,14 +3,33 @@ using System.Collections.Generic;
 using System.Data;
 using sprint0.Link;
 using sprint0.Items;
-
+using sprint0.Items.groundItems;
+using sprint0.Blocks;
+using sprint0.Enemies;
 
 namespace sprint0.Collision
 {
 	public class CollisionHandler
 	{
-		// Data structures needed to put this show on the road QUICKLY.
-		private DataTable collisionTable = new DataTable();
+        /*
+         * DEVELOPMENT NOTES:
+         * 
+         * 1. Stair Blocks lead nowhere currently.
+         * 2. Enemies handle their own knockback so the direction they face is slightky office.
+         * 3. Still need inventory system edits.
+         * 4. Still need enemy projectiles.
+         * 5. Still need  doors.
+         * 
+         * Things to note:
+         * 1. Link does not collide with any of his items in action.
+         * 2. Enemies don't collide with movable blocks or ground Items.
+         * 3. Bomb Boundary Collision
+         */
+
+
+
+        // Data structures needed to put this show on the road QUICKLY.
+        private DataTable collisionTable = new DataTable();
 
         /*
 		 * Constructor. May do more now that you can make an instance of this
@@ -24,7 +43,8 @@ namespace sprint0.Collision
 
         /*
 		 * Public method called from outside the handler class to begin 
-		 * handling of the two objects detected in a collision.
+		 * handling of the two objects detected in a collision. Returns true if a handler
+		 * exists for that combination.
 		 * 
 		 * DESIGN DETAILS FOR FUTUTE ME WHO HAS YET TO IMPLEMENT:
 		 * -----
@@ -41,23 +61,17 @@ namespace sprint0.Collision
 		 * Get type of an IGameObject returns the concrete class. So it's
 		 * really important our GameObjects implement the IGameObject interface
 		 */
-        public void HandleCollision(IGameObject a, IGameObject b, CollisionDetector.CollisionType collisionType)
+        public bool HandleCollision(IGameObject a, IGameObject b, CollisionDetector.CollisionType collisionType)
 		{
+            bool handleExists = false;
             String objAType = a.GetType().ToString();
             String objBType = b.GetType().ToString();
             DataRow rowWithDelegates = null;
             foreach (DataRow row in collisionTable.Rows)
             {
-                //AB check.
                 if (row["ObjectA"].Equals(objAType) && row["ObjectB"].Equals(objBType)) {
                     rowWithDelegates = row;
-                    break;
-                }
-
-                //BA check
-                else if (row["ObjectA"].Equals(objBType) && row["ObjectB"].Equals(objAType))
-                {
-                    rowWithDelegates = row;
+                    handleExists = true;
                     break;
                 }
             }
@@ -74,6 +88,8 @@ namespace sprint0.Collision
                     bDelegate(collisionType, b);
                 }
             }
+
+            return handleExists;
         }
 
 		/*
@@ -104,13 +120,132 @@ namespace sprint0.Collision
             collisionTable.Columns.Add("HandleB");
 			LinkDelegate MoveLinkDelegate = MoveLink;
 			LinkDelegate MoveLinkAndTakeDamageDelegate = MoveLinkAndTakeDamage;
-			BlazeDelegate BlazeImpactDelegate = BlazeImpact;
-			collisionTable.Rows.Add(new Object[] { "ILink", "DungenDrangonBlock", MoveLinkDelegate, null });
-            collisionTable.Rows.Add(new Object[] { "ILink", "DungenFishBlock", MoveLinkDelegate, null });
-            collisionTable.Rows.Add(new Object[] { "ILink", "DungenPyramidBlock", MoveLinkDelegate, null });
-			collisionTable.Rows.Add(new Object[] { "ILink", "ExplodableBlock", MoveLinkDelegate, null });
-            collisionTable.Rows.Add(new Object[] { "ILink", "Blaze", MoveLinkAndTakeDamageDelegate, BlazeImpactDelegate });
+            DungeonPyramidBlockDelegate MoveDungeonPyramidBlockDelegate = MoveDungeonPyramidBlock;
+            GroundBigHeartDelegate GroundBigHeartPickUpDelegate = GroundBigHeartPickUp;
+            GroundBlazeDelegate GroundBlazeSteppedOnDelegate = GroundBlazeSteppedOn;
+            GroundBoomerangDelegate GroundBoomerangPickUpDelegate = GroundBoomerangPickUp;
+            GroundCompassDelegate GroundCompassPickUpDelegate = GroundCompassPickUp;
+            GroundKeyDelegate GroundKeyPickUpDelegate = GroundKeyPickUp;
+            GroundPageDelegate GroundPagePickUpDelegate = GroundPagePickUp;
+            GroundTriforceDelegate GroundTriforcePickUpDelegate = GroundTriforcePickUp;
+            OktorokDelegate MoveOktorokDelegate = MoveOktorok;
+            OktorokDelegate MoveOktorokAndTakeDamageDelegate = MoveOktorokAndTakeDamage;
+            SkeletonDelegate MoveSkeletonDelegate = MoveSkeleton;
+            SkeletonDelegate MoveSkeletonAndTakeDamageDelegate = MoveSkeletonAndTakeDamage;
+            BokoblinDelegate MoveBokoblinDelegate = MoveBokoblin;
+            BokoblinDelegate MoveBokoblinAndTakeDamageDelegate = MoveBokoblinAndTakeDamage;
+            BowDelegate BowImpactDelegate = BowImpact;
+            BetterBowDelegate BetterBowImpactDelegate = BetterBowImpact;
+            BoomerangDelegate BoomerangImpactDelegate = BoomerangImpact; 
+            BetterBoomerangDelegate BetterBoomerangImpactDelegate = BetterBoomerangImpact;
+            BlazeDelegate BlazeImpactDelegate = BlazeImpact;
+            BombDelegate BombImpactDelegate = BombImpact;
+
+            // BOUNDARIES
+            collisionTable.Rows.Add(new Object[] { "Link", "Boundary", MoveLinkDelegate, null });
+            collisionTable.Rows.Add(new Object[] { "Skeleton", "Boundary", MoveSkeletonDelegate, null });
+            collisionTable.Rows.Add(new Object[] { "Bokoblin", "Boundary", MoveBokoblinDelegate, null });
+            collisionTable.Rows.Add(new Object[] { "Oktorok", "Boundary", MoveOktorokDelegate, null });
+            collisionTable.Rows.Add(new Object[] { "Bow", "Boundary", BowImpactDelegate, null });
+            collisionTable.Rows.Add(new Object[] { "BetterBow", "Boundary", BetterBowImpactDelegate, null });
+            collisionTable.Rows.Add(new Object[] { "Boomerang", "Boundary", BoomerangImpactDelegate, null });
+            collisionTable.Rows.Add(new Object[] { "BetterBoomerang", "Boundary", BetterBoomerangImpactDelegate, null });
+            collisionTable.Rows.Add(new Object[] { "Blaze", "Boundary", BlazeImpactDelegate, null });
+            collisionTable.Rows.Add(new Object[] { "Bomb", "Boundary", null, null });
+
+            // BLOCKS
+            collisionTable.Rows.Add(new Object[] { "Link", "DungeonDragonBlock", MoveLinkDelegate, null });
+            collisionTable.Rows.Add(new Object[] { "Skeleton", "DungeonDragonBlock", MoveSkeletonDelegate, null });
+            collisionTable.Rows.Add(new Object[] { "Bokoblin", "DungeonDragonBlock", MoveBokoblinDelegate, null });
+            collisionTable.Rows.Add(new Object[] { "Oktorok", "DungeonDragonBlock", MoveOktorokDelegate, null });
+
+            collisionTable.Rows.Add(new Object[] { "Link", "DungeonFishBlock", MoveLinkDelegate, null });
+            collisionTable.Rows.Add(new Object[] { "Skeleton", "DungeonFishBlock", MoveSkeletonDelegate, null });
+            collisionTable.Rows.Add(new Object[] { "Bokoblin", "DungeonFishBlock", MoveBokoblinDelegate, null });
+            collisionTable.Rows.Add(new Object[] { "Oktorok", "DungeonFishBlock", MoveOktorokDelegate, null });
+
+            collisionTable.Rows.Add(new Object[] { "Link", "DungeonPyramidBlock", null, MoveDungeonPyramidBlockDelegate });
+            collisionTable.Rows.Add(new Object[] { "Skeleton", "DungeonPyramidBlock", MoveSkeletonDelegate, null });
+            collisionTable.Rows.Add(new Object[] { "Bokoblin", "DungeonPyramidBlock", MoveBokoblinDelegate, null });
+            collisionTable.Rows.Add(new Object[] { "Oktorok", "DungeonPyramidBlock", MoveOktorokDelegate, null });
+
+            collisionTable.Rows.Add(new Object[] { "Link", "WaterBlock", MoveLinkDelegate, null });
+            collisionTable.Rows.Add(new Object[] { "Skeleton", "WaterBlock", MoveSkeletonDelegate, null });
+            collisionTable.Rows.Add(new Object[] { "Bokoblin", "WaterBlock", MoveBokoblinDelegate, null });
+            collisionTable.Rows.Add(new Object[] { "Oktorok", "WaterBlock", MoveOktorokDelegate, null });
+
+            collisionTable.Rows.Add(new Object[] { "Link", "RedPyramidBlock", null, MoveDungeonPyramidBlockDelegate });
+            collisionTable.Rows.Add(new Object[] { "Skeleton", "RedPyramidBlock", MoveSkeletonDelegate, null });
+            collisionTable.Rows.Add(new Object[] { "Bokoblin", "RedPyramidBlock", MoveBokoblinDelegate, null });
+            collisionTable.Rows.Add(new Object[] { "Oktorok", "RedPyramidBlock", MoveOktorokDelegate, null });
+
+            collisionTable.Rows.Add(new Object[] { "Link", "GrassBlock", null, null });
+            collisionTable.Rows.Add(new Object[] { "Skeleton", "GrassBlock", null, null });
+            collisionTable.Rows.Add(new Object[] { "Bokoblin", "GrassBlock", null, null });
+            collisionTable.Rows.Add(new Object[] { "Oktorok", "GrassBlock", null, null });
+
+            collisionTable.Rows.Add(new Object[] { "Link", "BlackBlock", null, null });
+            collisionTable.Rows.Add(new Object[] { "Skeleton", "BlackBlock", null, null });
+            collisionTable.Rows.Add(new Object[] { "Bokoblin", "BlackBlock", null, null });
+            collisionTable.Rows.Add(new Object[] { "Oktorok", "BlackBlock", null, null });
+
+            collisionTable.Rows.Add(new Object[] { "Link", "DungeonBlueBlock", null, null });
+            collisionTable.Rows.Add(new Object[] { "Skeleton", "DungeonBlueBlock", null, null });
+            collisionTable.Rows.Add(new Object[] { "Bokoblin", "DungeonBlueBlock", null, null });
+            collisionTable.Rows.Add(new Object[] { "Oktorok", "DungeonBlueBlock", null, null });
+
+            collisionTable.Rows.Add(new Object[] { "Link", "BlueFishBlock", MoveLinkDelegate, null });
+            collisionTable.Rows.Add(new Object[] { "Skeleton", "BlueFishBlock", MoveSkeletonDelegate, null });
+            collisionTable.Rows.Add(new Object[] { "Bokoblin", "BlueFishBlock", MoveBokoblinDelegate, null });
+            collisionTable.Rows.Add(new Object[] { "Oktorok", "BlueFishBlock", MoveOktorokDelegate, null });
+
+            collisionTable.Rows.Add(new Object[] { "Link", "BlueDragonBlock", MoveLinkDelegate, null });
+            collisionTable.Rows.Add(new Object[] { "Skeleton", "BlueDragonBlock", MoveSkeletonDelegate, null });
+            collisionTable.Rows.Add(new Object[] { "Bokoblin", "BlueDragonBlock", MoveBokoblinDelegate, null });
+            collisionTable.Rows.Add(new Object[] { "Oktorok", "BlueDragonBlock", MoveOktorokDelegate, null });
+
+            // LINK ITEMS + GROUND ITEMS
+            //Grounds
+            collisionTable.Rows.Add(new Object[] { "Link", "GroundBigHeart", null, GroundBigHeartPickUpDelegate });
+            collisionTable.Rows.Add(new Object[] { "Link", "GroundBlaze", null, GroundBlazeSteppedOnDelegate });
+            collisionTable.Rows.Add(new Object[] { "Link", "GroundBoomerang", null, GroundBoomerangPickUpDelegate });
+            collisionTable.Rows.Add(new Object[] { "Link", "GroundCompass", null, GroundCompassPickUpDelegate });
+            collisionTable.Rows.Add(new Object[] { "Link", "GroundKey", null, GroundKeyPickUpDelegate });
+            collisionTable.Rows.Add(new Object[] { "Link", "GroundPage", null, GroundPagePickUpDelegate });
+            collisionTable.Rows.Add(new Object[] { "Link", "GroundTriforce", null, GroundTriforcePickUpDelegate });
+
+            //LinkItems
+            collisionTable.Rows.Add(new Object[] { "Bow", "Link", null, null });
+            collisionTable.Rows.Add(new Object[] { "Bow", "Bokoblin", BowImpactDelegate, MoveBokoblinAndTakeDamageDelegate });
+            collisionTable.Rows.Add(new Object[] { "Bow", "Oktorok", BowImpactDelegate, MoveOktorokAndTakeDamageDelegate });
+            collisionTable.Rows.Add(new Object[] { "Bow", "Skeleton", BowImpactDelegate, MoveSkeletonAndTakeDamageDelegate });
+
+            collisionTable.Rows.Add(new Object[] { "BetterBow", "Link", null, null });
+            collisionTable.Rows.Add(new Object[] { "BetterBow", "Bokoblin", BetterBowImpactDelegate, MoveBokoblinAndTakeDamageDelegate });
+            collisionTable.Rows.Add(new Object[] { "BetterBow", "Oktorok", BetterBowImpactDelegate, MoveOktorokAndTakeDamageDelegate });
+            collisionTable.Rows.Add(new Object[] { "BetterBow", "Skeleton", BetterBowImpactDelegate, MoveSkeletonAndTakeDamageDelegate });
+
+            collisionTable.Rows.Add(new Object[] { "Boomerang", "Link", null, null });
+            collisionTable.Rows.Add(new Object[] { "Boomerang", "Bokoblin", BoomerangImpactDelegate, MoveBokoblinAndTakeDamageDelegate });
+            collisionTable.Rows.Add(new Object[] { "Boomerang", "Oktorok", BoomerangImpactDelegate, MoveOktorokAndTakeDamageDelegate });
+            collisionTable.Rows.Add(new Object[] { "Boomerang", "Skeleton", BoomerangImpactDelegate, MoveSkeletonAndTakeDamageDelegate });
+
+            collisionTable.Rows.Add(new Object[] { "BetterBoomerang", "Link", null, null });
+            collisionTable.Rows.Add(new Object[] { "BetterBoomerang", "Bokoblin", BetterBoomerangImpactDelegate, MoveBokoblinAndTakeDamageDelegate });
+            collisionTable.Rows.Add(new Object[] { "BetterBoomerang", "Oktorok", BetterBoomerangImpactDelegate, MoveOktorokAndTakeDamageDelegate });
+            collisionTable.Rows.Add(new Object[] { "BetterBoomerang", "Skeleton", BetterBoomerangImpactDelegate, MoveSkeletonAndTakeDamageDelegate });
+
+            collisionTable.Rows.Add(new Object[] { "Blaze", "Link", null, null });
+            collisionTable.Rows.Add(new Object[] { "Blaze", "Bokoblin", BlazeImpactDelegate, MoveBokoblinAndTakeDamageDelegate });
+            collisionTable.Rows.Add(new Object[] { "Blaze", "Oktorok", BlazeImpactDelegate, MoveOktorokAndTakeDamageDelegate });
+            collisionTable.Rows.Add(new Object[] { "Blaze", "Skeleton", BlazeImpactDelegate, MoveSkeletonAndTakeDamageDelegate });
+
+            collisionTable.Rows.Add(new Object[] { "Bomb", "Bokoblin", BombImpactDelegate, MoveBokoblinAndTakeDamageDelegate });
+            collisionTable.Rows.Add(new Object[] { "Bomb", "Oktorok", BombImpactDelegate, MoveOktorokAndTakeDamageDelegate });
+            collisionTable.Rows.Add(new Object[] { "Bomb", "Skeleton", BombImpactDelegate, MoveSkeletonAndTakeDamageDelegate });
+            collisionTable.Rows.Add(new Object[] { "Bomb", "Link", null, null });
         }
+
 
         /*
 		 * DELEGATES & METHODS
@@ -130,10 +265,30 @@ namespace sprint0.Collision
 		 * 
 		 */
         private delegate void GameObjectDelegate(CollisionDetector.CollisionType collisionType, IGameObject obj);
+        //BLOCKS
+        private delegate void DungeonPyramidBlockDelegate(CollisionDetector.CollisionType collisionType, DungeonPyramidBlock block);
+        private void MoveDungeonPyramidBlock(CollisionDetector.CollisionType collisionType, DungeonPyramidBlock block)
+        {
+            switch (collisionType)
+            {
+                case CollisionDetector.CollisionType.TOP:
+                    block.YValue++;
+                    break;
+                case CollisionDetector.CollisionType.BOTTOM:
+                    block.YValue--;
+                    break;
+                case CollisionDetector.CollisionType.LEFT:
+                    block.XValue++;
+                    break;
+                case CollisionDetector.CollisionType.RIGHT:
+                    block.XValue--;
+                    break;
+            }
+        }
 
-		//LINK
-		private delegate void LinkDelegate(CollisionDetector.CollisionType collisionType, ILink link);
-        private void MoveLink (CollisionDetector.CollisionType collisionType, ILink link) {
+        //LINK
+        private delegate void LinkDelegate(CollisionDetector.CollisionType collisionType, Link.Link link);
+        private void MoveLink (CollisionDetector.CollisionType collisionType, Link.Link link) {
             // I need a better way to change Link's stuff without making such a mess.
             switch (collisionType)
 			{
@@ -152,7 +307,7 @@ namespace sprint0.Collision
             }
 		}
 
-        private void MoveLinkAndTakeDamage(CollisionDetector.CollisionType collisionType, ILink link)
+        private void MoveLinkAndTakeDamage(CollisionDetector.CollisionType collisionType, Link.Link link)
         {
             switch (collisionType)
             {
@@ -189,7 +344,7 @@ namespace sprint0.Collision
         }
 
         /*
-         * ITEMS
+         * LINK ITEMS
          * this is expecting the item... do not throw the entire item system obj
          */
 
@@ -228,9 +383,149 @@ namespace sprint0.Collision
 		private delegate void BombDelegate(CollisionDetector.CollisionType collisionType, Bomb bomb);
 		private void BombImpact(CollisionDetector.CollisionType collisionType, Bomb bomb)
 		{
-            // NOTE: Bomb doesn't have splash damage implemented yet for when it's finally exploded.
-            // DESIGN DECISION: should Bomb explode if an enemy collides with it?
+            // Collision with bomb in dormant state causes explosion to occur.
+            //COUPLING! EW!
+            if (bomb.bombTicks < bomb.maxBombTicks)
+            {
+                bomb.bombTicks = bomb.maxBombTicks;
+            }
         }
+
+        /*
+         * GROUND ITEMS
+         * Inventory system changes are included in these methods.
+         */
+
+        private delegate void GroundBigHeartDelegate(CollisionDetector.CollisionType collisionType, GroundBigHeart groundBigHeart);
+        private void GroundBigHeartPickUp(CollisionDetector.CollisionType collisionType, GroundBigHeart groundBigHeart)
+        {
+            groundBigHeart.PickUp();
+            // code that impacts inventory system goes here.
+        }
+
+        private delegate void GroundBoomerangDelegate(CollisionDetector.CollisionType collisionType, GroundBoomerang groundBoomerang);
+        private void GroundBoomerangPickUp(CollisionDetector.CollisionType collisionType, GroundBoomerang groundBoomerang)
+        {
+            groundBoomerang.PickUp();
+            // code that impacts inventory system goes here.
+        }
+        private delegate void GroundCompassDelegate(CollisionDetector.CollisionType collisionType, GroundCompass groundCompass);
+        private void GroundCompassPickUp(CollisionDetector.CollisionType collisionType, GroundCompass groundCompass)
+        {
+            groundCompass.PickUp();
+            // code that impacts inventory system goes here.
+        }
+
+        private delegate void GroundKeyDelegate(CollisionDetector.CollisionType collisionType, GroundKey groundKeyDelegate);
+        private void GroundKeyPickUp(CollisionDetector.CollisionType collisionType, GroundKey groundKey)
+        {
+            groundKey.PickUp();
+            // code that impacts inventory system goes here.
+        }
+
+        private delegate void GroundPageDelegate(CollisionDetector.CollisionType collisionType, GroundPage groundPage);
+        private void GroundPagePickUp(CollisionDetector.CollisionType collisionType, GroundPage groundPage)
+        {
+            groundPage.PickUp();
+            // code that impacts inventory system goes here.
+        }
+
+        private delegate void GroundTriforceDelegate(CollisionDetector.CollisionType collisionType, GroundTriforce groundTriforce);
+        private void GroundTriforcePickUp(CollisionDetector.CollisionType collisionType, GroundTriforce groundTriforce)
+        {
+            groundTriforce.PickUp();
+            // code that impacts inventory system goes here.
+        }
+
+        private delegate void GroundBlazeDelegate(CollisionDetector.CollisionType collisionType, GroundBlaze groundBlaze);
+        private void GroundBlazeSteppedOn(CollisionDetector.CollisionType collisionType, GroundBlaze groundBlaze)
+        {
+            groundBlaze.PickUp();
+            // code that impacts inventory system goes here.
+        }
+
+        // ENEMIES
+        /*
+         * Like Link, Enemies have methods to move pos
+         * Unlike Link, Enemies have knockback built into their take damage calls. Neat. Direction is built in too, but they should knock back in the direction they were hit.
+         */
+        private delegate void OktorokDelegate(CollisionDetector.CollisionType collisionType, Oktorok enemy);
+        private void MoveOktorok(CollisionDetector.CollisionType collisionType, Oktorok enemy)
+        {
+            switch (collisionType)
+            {
+                case CollisionDetector.CollisionType.TOP:
+                    enemy.OktorokUp();
+                    break;
+                case CollisionDetector.CollisionType.BOTTOM:
+                    enemy.OktorokDown();
+                    break;
+                case CollisionDetector.CollisionType.LEFT:
+                    enemy.OktorokLeft();
+                    break;
+                case CollisionDetector.CollisionType.RIGHT:
+                    enemy.OktorokRight();
+                    break;
+            }
+        }
+
+        private void MoveOktorokAndTakeDamage(CollisionDetector.CollisionType collisionType, Oktorok enemy)
+        {
+            enemy.TakeDamage();
+        }
+
+        private delegate void SkeletonDelegate(CollisionDetector.CollisionType collisionType, Skeleton enemy);
+        private void MoveSkeleton(CollisionDetector.CollisionType collisionType, Skeleton enemy)
+        {
+            switch (collisionType)
+            {
+                case CollisionDetector.CollisionType.TOP:
+                    enemy.SkeletonUp();
+                    break;
+                case CollisionDetector.CollisionType.BOTTOM:
+                    enemy.SkeletonDown();
+                    break;
+                case CollisionDetector.CollisionType.LEFT:
+                    enemy.SkeletonLeft();
+                    break;
+                case CollisionDetector.CollisionType.RIGHT:
+                    enemy.SkeletonRight();
+                    break;
+            }
+        }
+
+        private void MoveSkeletonAndTakeDamage(CollisionDetector.CollisionType collisionType, Skeleton enemy)
+        {
+
+            enemy.takeDamage();
+        }
+
+        private delegate void BokoblinDelegate (CollisionDetector.CollisionType collisionType, Bokoblin enemy);
+        private void MoveBokoblin(CollisionDetector.CollisionType collisionType, Bokoblin enemy)
+        {
+            switch (collisionType)
+            {
+                case CollisionDetector.CollisionType.TOP:
+                    enemy.BokoblinUp();
+                    break;
+                case CollisionDetector.CollisionType.BOTTOM:
+                    enemy.BokoblinDown();
+                    break;
+                case CollisionDetector.CollisionType.LEFT:
+                    enemy.BokoblinLeft();
+                    break;
+                case CollisionDetector.CollisionType.RIGHT:
+                    enemy.BokoblinRight();
+                    break;
+            }
+        }
+
+        private void MoveBokoblinAndTakeDamage(CollisionDetector.CollisionType collisionType, Bokoblin enemy)
+        {
+
+            enemy.TakeDamage();
+        }
+
     }
 }
 

--- a/sprint0/Collision/CollisionIterator.cs
+++ b/sprint0/Collision/CollisionIterator.cs
@@ -31,6 +31,7 @@ namespace sprint0.Collision
 		 */
 
 		private const int INITIATE_LOOP_THRESHOLD = 4;
+        private static CollisionHandler handler = new CollisionHandler();
 
         public static void Search(IList<IGameObject> collidables, int screenWidth, int screenHeight)
         {
@@ -71,7 +72,23 @@ namespace sprint0.Collision
 				{
                     foreach (IGameObject obj2 in collidablesInQuadrant)
 					{
-						CollisionDetector.CollisionCheck(obj1, obj2);
+						CollisionDetector.CollisionType thisCollisionType = CollisionDetector.CollisionCheck(obj1, obj2);
+`						if (thisCollisionType != CollisionDetector.CollisionType.NONE)
+						{
+							bool foundCollision = handler.HandleCollision(obj1, obj2, thisCollisionType);
+							if (!foundCollision)
+							{
+                                foundCollision = handler.HandleCollision(obj2, obj1, thisCollisionType); // BA Check.
+								if(!foundCollision)
+								{
+                                    Console.WriteLine("DEBUG: COLLISION HANDLER COULD NOT FIND HANDLER FOR COMBINATION OF OBJECT:" + obj1.GetType().ToString() + " AND " + obj2.GetType().ToString());
+                                }
+							} else
+							{
+                                Console.WriteLine("DEBUG: COLLISION HAS OCCURRED BETWEEN:" + obj1.GetType().ToString() + " AND " + obj2.GetType().ToString());
+                            }
+						}
+
 					}
 
                 }

--- a/sprint0/Items/equippedBomb/Bomb.cs
+++ b/sprint0/Items/equippedBomb/Bomb.cs
@@ -8,9 +8,8 @@ namespace sprint0.Items
     {
         private int itemXPos;
         private int itemYPos;
-        private int maxBombTicks;
-        private int bombTicks;
-        private int RoomId;
+        public int maxBombTicks;
+        public int bombTicks;
         // needs these positions for sprite swapping.
 
         //direction stuff


### PR DESCRIPTION
**WHAT CHANGED?**

BA CHECK:
1. BA check in Collision Handler so that there doesnt need to be double the number of delegates.
2. I added a swap too in the event that if a BA does occur, then the delegates can be swapped so that HandleB handles A and vice versa, though I'm not sure if this is necessary.

EXPANSION:
1. Added Collision between several game objects including enemies, boundaries, doors, link items, and ground items. Things that are missing (to my knowledge) are commented in the Handler file.
2. Apparently Pyramid Blocks can be pushed so they were refactored in order to implement that.