### PR TITLE
SoundSystem + ItemSystem: Sound Effects and Item Spawn Adjustments

### DIFF
--- a/sprint0/Collision/CollisionHandler.cs
+++ b/sprint0/Collision/CollisionHandler.cs
@@ -6,6 +6,7 @@ using sprint0.Items;
 using sprint0.Items.groundItems;
 using sprint0.Blocks;
 using sprint0.Enemies;
+using sprint0.Sound.Ocarina;
 
 namespace sprint0.Collision
 {
@@ -345,6 +346,7 @@ namespace sprint0.Collision
                     break;
             }
 			link.LinkTakeDamage();
+            Ocarina.PlaySoundEffect(Ocarina.SoundEffects.LINK_TAKE_DAMAGE);
         }
 
         /*
@@ -404,6 +406,7 @@ namespace sprint0.Collision
         private void GroundBigHeartPickUp(CollisionDetector.CollisionType collisionType, GroundBigHeart groundBigHeart)
         {
             groundBigHeart.PickUp();
+            Ocarina.PlaySoundEffect(Ocarina.SoundEffects.GET_GROUND_HEART_KEY);
             // code that impacts inventory system goes here.
         }
 
@@ -411,12 +414,14 @@ namespace sprint0.Collision
         private void GroundBoomerangPickUp(CollisionDetector.CollisionType collisionType, GroundBoomerang groundBoomerang)
         {
             groundBoomerang.PickUp();
+            Ocarina.PlaySoundEffect(Ocarina.SoundEffects.LINK_ITEM_GET);
             // code that impacts inventory system goes here.
         }
         private delegate void GroundCompassDelegate(CollisionDetector.CollisionType collisionType, GroundCompass groundCompass);
         private void GroundCompassPickUp(CollisionDetector.CollisionType collisionType, GroundCompass groundCompass)
         {
             groundCompass.PickUp();
+            Ocarina.PlaySoundEffect(Ocarina.SoundEffects.LINK_ITEM_GET);
             // code that impacts inventory system goes here.
         }
 
@@ -424,6 +429,7 @@ namespace sprint0.Collision
         private void GroundKeyPickUp(CollisionDetector.CollisionType collisionType, GroundKey groundKey)
         {
             groundKey.PickUp();
+            Ocarina.PlaySoundEffect(Ocarina.SoundEffects.GET_GROUND_HEART_KEY);
             // code that impacts inventory system goes here.
         }
 
@@ -431,6 +437,7 @@ namespace sprint0.Collision
         private void GroundPagePickUp(CollisionDetector.CollisionType collisionType, GroundPage groundPage)
         {
             groundPage.PickUp();
+            Ocarina.PlaySoundEffect(Ocarina.SoundEffects.LINK_ITEM_GET);
             // code that impacts inventory system goes here.
         }
 
@@ -438,6 +445,8 @@ namespace sprint0.Collision
         private void GroundTriforcePickUp(CollisionDetector.CollisionType collisionType, GroundTriforce groundTriforce)
         {
             groundTriforce.PickUp();
+            WindWaker.PauseSong(WindWaker.Songs.DUNGEON); //Should pause this song if playing.
+            WindWaker.PlaySong(WindWaker.Songs.TRIFORCE_OBTAIN);
             // code that impacts inventory system goes here.
         }
 
@@ -445,6 +454,7 @@ namespace sprint0.Collision
         private void GroundBlazeSteppedOn(CollisionDetector.CollisionType collisionType, GroundBlaze groundBlaze)
         {
             groundBlaze.PickUp();
+            Ocarina.PlaySoundEffect(Ocarina.SoundEffects.LINK_ITEM_GET);
             // code that impacts inventory system goes here.
         }
 
@@ -476,6 +486,7 @@ namespace sprint0.Collision
         private void MoveOktorokAndTakeDamage(CollisionDetector.CollisionType collisionType, Oktorok enemy)
         {
             enemy.TakeDamage();
+            Ocarina.PlaySoundEffect(Ocarina.SoundEffects.ENEMY_HIT);
         }
 
         private delegate void SkeletonDelegate(CollisionDetector.CollisionType collisionType, Skeleton enemy);
@@ -502,6 +513,7 @@ namespace sprint0.Collision
         {
 
             enemy.takeDamage();
+            Ocarina.PlaySoundEffect(Ocarina.SoundEffects.ENEMY_HIT);
         }
 
         private delegate void BokoblinDelegate (CollisionDetector.CollisionType collisionType, Bokoblin enemy);
@@ -528,6 +540,7 @@ namespace sprint0.Collision
         {
 
             enemy.TakeDamage();
+            Ocarina.PlaySoundEffect(Ocarina.SoundEffects.ENEMY_HIT);
         }
 
     }

--- a/sprint0/Commands/AttackCommand.cs
+++ b/sprint0/Commands/AttackCommand.cs
@@ -5,6 +5,7 @@ using System.Text;
 using System.Threading.Tasks;
 using sprint0;
 using sprint0.Link;
+using sprint0.Sound.Ocarina;
 
 namespace sprint0.Commands
 {
@@ -26,7 +27,7 @@ namespace sprint0.Commands
         {
             Link.LinkUseItem();
             LinkItems.UseCurrentItem(Link.GetDirection(), Link.xPosition(), Link.yPosition(), Link.height(), Link.width());
-
+          
         }
     }
 }

--- a/sprint0/Commands/DamangedCommand.cs
+++ b/sprint0/Commands/DamangedCommand.cs
@@ -5,6 +5,7 @@ using System.Text;
 using System.Threading.Tasks;
 using sprint0;
 using sprint0.Link;
+using sprint0.Sound.Ocarina;
 
 namespace sprint0.Commands
 {
@@ -22,6 +23,8 @@ namespace sprint0.Commands
         public void execute()
         {
             Link.LinkTakeDamage();
+            //Ocarina.PlaySoundEffect(Ocarina.SoundEffects.LINK_TAKE_DAMAGE);
+            // might remove this since collision handler may take care of this.
         }
     }
 }

--- a/sprint0/Game1.cs
+++ b/sprint0/Game1.cs
@@ -231,7 +231,35 @@ namespace sprint0
             Ocarina.LoadSoundEffect(Ocarina.SoundEffects.SWORD_SLASH, SWORD_SLASH);
             Ocarina.LoadSoundEffect(Ocarina.SoundEffects.SWORD_SHOOT, SWORD_SHOOT);
             Ocarina.LoadSoundEffect(Ocarina.SoundEffects.SHIELD, SHIELD);
-            Ocarina.LoadSoundEffect(Ocarina.SoundEffects.SHIELD, SHIELD);
+            Ocarina.LoadSoundEffect(Ocarina.SoundEffects.BOOMERANG_LAUNCH, ARROW_BOOMERANG_LAUNCH, true);
+            Ocarina.LoadSoundEffect(Ocarina.SoundEffects.ARROW_LAUNCH, ARROW_BOOMERANG_LAUNCH, false);
+            Ocarina.LoadSoundEffect(Ocarina.SoundEffects.BOMB_DROP, BOMB_DROP);
+            Ocarina.LoadSoundEffect(Ocarina.SoundEffects.BOMB_EXPLODE, BOMB_EXPLODE);
+            Ocarina.LoadSoundEffect(Ocarina.SoundEffects.ENEMY_HIT, ENEMY_HIT);
+            Ocarina.LoadSoundEffect(Ocarina.SoundEffects.ENEMY_DIE, ENEMY_DIE);
+            Ocarina.LoadSoundEffect(Ocarina.SoundEffects.LINK_TAKE_DAMAGE, LINK_TAKE_DAMAGE);
+            Ocarina.LoadSoundEffect(Ocarina.SoundEffects.LINK_DEATH, LINK_DEATH);
+            Ocarina.LoadSoundEffect(Ocarina.SoundEffects.LINK_LOW_HEALTH, LINK_LOW_HEALTH);
+            Ocarina.LoadSoundEffect(Ocarina.SoundEffects.FANFARE, FANFARE);
+            Ocarina.LoadSoundEffect(Ocarina.SoundEffects.LINK_ITEM_GET, LINK_ITEM_GET);
+            Ocarina.LoadSoundEffect(Ocarina.SoundEffects.GET_GROUND_HEART_KEY, GET_GROUND_HEART_KEY);
+            Ocarina.LoadSoundEffect(Ocarina.SoundEffects.GET_GROUND_RUPEE, GET_GROUND_RUPEE);
+            Ocarina.LoadSoundEffect(Ocarina.SoundEffects.REFILL, REFILL);
+            Ocarina.LoadSoundEffect(Ocarina.SoundEffects.TEXT_APPEAR, TEXT_APPEAR);
+            Ocarina.LoadSoundEffect(Ocarina.SoundEffects.GROUND_KEY_APPEAR, GROUND_KEY_APPEAR);
+            Ocarina.LoadSoundEffect(Ocarina.SoundEffects.DOOR_UNLOCK, DOOR_UNLOCK);
+            Ocarina.LoadSoundEffect(Ocarina.SoundEffects.BOSS_AQUAMENTUS_SCREAM, BOSS_AQUAMENTUS_SCREAM);
+            Ocarina.LoadSoundEffect(Ocarina.SoundEffects.BOSS_TAKE_DAMAGE, BOSS_TAKE_DAMAGE);
+            Ocarina.LoadSoundEffect(Ocarina.SoundEffects.STAIRS, STAIRS);
+            Ocarina.LoadSoundEffect(Ocarina.SoundEffects.PUZZLE_SOLVED, PUZZLE_SOLVED);
+            Ocarina.LoadSoundEffect(Ocarina.SoundEffects.BLAZE, BLAZE);
+
+
+
+
+
+
+
 
 
             //Songs

--- a/sprint0/Items/equippedBlaze/Blaze.cs
+++ b/sprint0/Items/equippedBlaze/Blaze.cs
@@ -2,6 +2,8 @@
 using System.Collections.Generic;
 using Microsoft.Xna.Framework.Graphics;
 using sprint0.AnimatedSpriteFactory;
+using sprint0.Sound.Ocarina;
+
 namespace sprint0.Items
 {
     public class Blaze : IItem, IGameObject
@@ -92,6 +94,7 @@ namespace sprint0.Items
         {
             if (!thisStateMachine.isItemInUse())
             {
+                Ocarina.PlaySoundEffect(Ocarina.SoundEffects.BLAZE);
                 thisStateMachine.Use(); // sets usage in play
                 this.itemXPos = linkXPos;
                 this.itemYPos = linkYPos;

--- a/sprint0/Items/equippedBomb/Bomb.cs
+++ b/sprint0/Items/equippedBomb/Bomb.cs
@@ -2,6 +2,8 @@
 using System.Collections.Generic;
 using Microsoft.Xna.Framework.Graphics;
 using sprint0.AnimatedSpriteFactory;
+using sprint0.Sound.Ocarina;
+
 namespace sprint0.Items
 {
     public class Bomb : IItem, IGameObject
@@ -70,6 +72,7 @@ namespace sprint0.Items
             {
                 this.currentItemSprite = explosionSpriteFactory.getAnimatedSprite("BombExplosion");
                 this.spriteChanged = true;
+                Ocarina.PlaySoundEffect(Ocarina.SoundEffects.BOMB_EXPLODE);
             }
             else if (this.finishedAnimationCycle() && this.spriteChanged)
             {
@@ -85,6 +88,7 @@ namespace sprint0.Items
         {
             if (!thisStateMachine.isItemInUse())
             {
+                Ocarina.PlaySoundEffect(Ocarina.SoundEffects.BOMB_DROP);
                 this.spriteChanged = false; //reset
                 thisStateMachine.Use(); // sets usage in play
                 

--- a/sprint0/Items/equippedBoomerangs/BetterBoomerang.cs
+++ b/sprint0/Items/equippedBoomerangs/BetterBoomerang.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using Microsoft.Xna.Framework.Graphics;
 using sprint0.AnimatedSpriteFactory;
+using sprint0.Sound.Ocarina;
 
 namespace sprint0.Items
 {
@@ -75,6 +76,7 @@ namespace sprint0.Items
                         thisStateMachine.CeaseUse();
                         this.spriteChanged = false; //reset
                         this.currentItemSprite = null;
+                        Ocarina.StopSoundEffect(Ocarina.SoundEffects.BOOMERANG_LAUNCH);
                     }
                 }
                 else
@@ -133,6 +135,7 @@ namespace sprint0.Items
         {
             if (!thisStateMachine.isItemInUse())
             {
+                Ocarina.PlaySoundEffect(Ocarina.SoundEffects.BOOMERANG_LAUNCH);
                 this.spriteChanged = false; //reset
                 thisStateMachine.Use(); // sets usage in play
                 this.itemXPos = linkXPos;

--- a/sprint0/Items/equippedBoomerangs/Boomerang.cs
+++ b/sprint0/Items/equippedBoomerangs/Boomerang.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using Microsoft.Xna.Framework.Graphics;
 using sprint0.AnimatedSpriteFactory;
+using sprint0.Sound.Ocarina;
 
 namespace sprint0.Items
 {
@@ -75,6 +76,7 @@ namespace sprint0.Items
                         thisStateMachine.CeaseUse();
                         this.spriteChanged = false; //reset
                         this.currentItemSprite = null;
+                        Ocarina.StopSoundEffect(Ocarina.SoundEffects.BOOMERANG_LAUNCH);
                     }
                 }
                 else
@@ -133,6 +135,7 @@ namespace sprint0.Items
         {
             if (!thisStateMachine.isItemInUse())
             {
+                Ocarina.PlaySoundEffect(Ocarina.SoundEffects.BOOMERANG_LAUNCH);
                 this.spriteChanged = false; //reset
                 thisStateMachine.Use(); // sets usage in play
                 this.itemXPos = linkXPos;

--- a/sprint0/Items/equippedBows/BetterBow.cs
+++ b/sprint0/Items/equippedBows/BetterBow.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using Microsoft.Xna.Framework.Graphics;
 using sprint0.Items;
 using sprint0.AnimatedSpriteFactory;
+using sprint0.Sound.Ocarina;
 
 namespace sprint0.Items
 {
@@ -109,6 +110,7 @@ namespace sprint0.Items
 
             if (!thisStateMachine.isItemInUse())
             {
+                Ocarina.PlaySoundEffect(Ocarina.SoundEffects.ARROW_LAUNCH);
                 this.spriteChanged = false; //reset
                 thisStateMachine.Use(); // sets usage in play
                 this.itemXPos = linkXPos;
@@ -124,11 +126,11 @@ namespace sprint0.Items
                 switch (linkDirection)
                 {
                     case (int)Direction.RIGHT:
-                        rotation = -90;
+                        rotation = (float)67.5;
                         currentItemDirection = Direction.RIGHT;
                         break;
                     case (int)Direction.UP:
-                        rotation = 180;
+                        rotation = (float)135;
                         currentItemDirection = Direction.UP;
                         break;
                     case (int)Direction.DOWN:
@@ -136,7 +138,7 @@ namespace sprint0.Items
                         currentItemDirection = Direction.DOWN;
                         break;
                     case (int)Direction.LEFT:
-                        rotation = 90;
+                        rotation = (float)-67.5;
                         currentItemDirection = Direction.LEFT;
                         break;
                 }

--- a/sprint0/Items/equippedBows/Bow.cs
+++ b/sprint0/Items/equippedBows/Bow.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using Microsoft.Xna.Framework.Graphics;
 using sprint0.Items;
 using sprint0.AnimatedSpriteFactory;
+using sprint0.Sound.Ocarina;
 
 namespace sprint0.Items
 {
@@ -109,6 +110,7 @@ namespace sprint0.Items
 
             if (!thisStateMachine.isItemInUse())
             {
+                Ocarina.PlaySoundEffect(Ocarina.SoundEffects.ARROW_LAUNCH);
                 this.spriteChanged = false; //reset
                 thisStateMachine.Use(); // sets usage in play
                 this.itemXPos = linkXPos;
@@ -124,11 +126,11 @@ namespace sprint0.Items
                 switch (linkDirection)
                 {
                     case (int)Direction.RIGHT:
-                        rotation = -90;
+                        rotation = (float)67.5;
                         currentItemDirection = Direction.RIGHT;
                         break;
                     case (int)Direction.UP:
-                        rotation = 180;
+                        rotation = (float)135;
                         currentItemDirection = Direction.UP;
                         break;
                     case (int)Direction.DOWN:
@@ -136,7 +138,7 @@ namespace sprint0.Items
                         currentItemDirection = Direction.DOWN;
                         break;
                     case (int)Direction.LEFT:
-                        rotation = 90;
+                        rotation = (float)-67.5;
                         currentItemDirection = Direction.LEFT;
                         break;
                 }

--- a/sprint0/Items/linkSword/Sword.cs
+++ b/sprint0/Items/linkSword/Sword.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using Microsoft.Xna.Framework.Graphics;
 using sprint0.AnimatedSpriteFactory;
 using sprint0.Items;
+using sprint0.Sound.Ocarina;
 
 namespace sprint0.LinkSword
 {
@@ -32,6 +33,8 @@ namespace sprint0.LinkSword
         private IItemStateMachine thisStateMachine;
         private Direction currentItemDirection;
         private bool isDrawn;
+        private int totalSwordTicks = 25;
+        private int currentSwordTicks;
 
         private enum Direction { LEFT, RIGHT, UP, DOWN };
 
@@ -45,6 +48,7 @@ namespace sprint0.LinkSword
             rotation = 0;
             itemSpriteFactory = factory;
             currentItemSprite = itemSpriteFactory.getAnimatedSprite("ItemDown");
+            currentSwordTicks = 0;
         }
 
         public void Draw(SpriteBatch spritebatch)
@@ -62,7 +66,7 @@ namespace sprint0.LinkSword
                         currentItemSprite.Draw(spritebatch, xPos + linkWidth, yPos - (linkHeight / 2), rotation);
                         break;
                     case Direction.DOWN:
-                        currentItemSprite.Draw(spritebatch, xPos + (linkWidth / 2), yPos + linkHeight, rotation);
+                        currentItemSprite.Draw(spritebatch, xPos + (linkWidth / 6), yPos, rotation);
                         break;
                     case Direction.UP:
                         currentItemSprite.Draw(spritebatch, xPos + (linkWidth / 2), yPos - linkHeight, rotation);
@@ -83,6 +87,8 @@ namespace sprint0.LinkSword
 
         public void Use(int linkDirection, int linkXPos, int linkYPos, int linkHeight, int linkWidth)
         {
+            currentSwordTicks = 0;
+            Ocarina.PlaySoundEffect(Ocarina.SoundEffects.SWORD_SLASH);
             thisStateMachine.Use();
             this.xPos = linkXPos;
             this.yPos = linkYPos;
@@ -101,11 +107,11 @@ namespace sprint0.LinkSword
                     break;
                 case Direction.UP:
                     currentItemSprite = itemSpriteFactory.getAnimatedSprite("ItemUp");
-                    rotation = -90;
+                    rotation = (float)-67.5;
                     break;
                 case Direction.DOWN:
                     currentItemSprite = itemSpriteFactory.getAnimatedSprite("ItemDown");
-                    rotation = 90;
+                    rotation = (float)67.5;
                     break;
             }
             isDrawn = true;
@@ -116,11 +122,14 @@ namespace sprint0.LinkSword
           /* if the amount of time thats passed is equal to or exceeds the max amount of time for a sword to be drawn, 
            * set isDrawn to false.
            */
-          if (currentItemSprite.GetCurrentFrame() > currentItemSprite.GetTotalFrames()) {
+          //if (currentItemSprite.GetCurrentFrame() > currentItemSprite.GetTotalFrames()) {
+          if (currentSwordTicks >= totalSwordTicks) { 
                 this.isDrawn = false;
                 this.thisStateMachine.CeaseUse();
+                
             }
-
+            currentItemSprite.Update();
+            currentSwordTicks++;
 
         }
 

--- a/sprint0/Sound/Ocarina/Ocarina.cs
+++ b/sprint0/Sound/Ocarina/Ocarina.cs
@@ -20,6 +20,8 @@ namespace sprint0.Sound.Ocarina
             BOSS_AQUAMENTUS_SCREAM, BOSS_TAKE_DAMAGE, STAIRS, PUZZLE_SOLVED,
             BLAZE
         };
+        private static IDictionary<Ocarina.SoundEffects, SoundEffectInstance>
+            InPlaySound = new Dictionary<Ocarina.SoundEffects, SoundEffectInstance>();
         private static IDictionary<SoundEffects, OcarinaEffectData> Library 
             = new Dictionary<SoundEffects, OcarinaEffectData>();
 
@@ -48,6 +50,10 @@ namespace sprint0.Sound.Ocarina
                     effectInstance.IsLooped = true;
                 }
                 effectInstance.Play();
+                if (!InPlaySound.ContainsKey(sfxName))
+                {
+                    InPlaySound.Add(sfxName, effectInstance);
+                }
                 
 
             } else
@@ -56,27 +62,21 @@ namespace sprint0.Sound.Ocarina
             }
 
         }
-        //// Stops the given sound effect on the assumption that it was properly loaded into the system.
-        //// As well as is currently playing. If not, will print error to console.
-        //public static void StopSoundEffect(Ocarina.SoundEffects sfxName)
-        //{
-        //    if (Library.ContainsKey(sfxName))
-        //    {
-        //        OcarinaEffectData effectData = Library[sfxName];
-        //        SoundEffectInstance effectInstance = effectData.sfx.CreateInstance();
-        //        if (effectData.isLoopable)
-        //        {
-        //            effectInstance.IsLooped = true;
-        //        }
-        //        effectInstance.Play();
+        // Stops the given sound effect on the assumption that it was properly loaded into the system.
+        // As well as is currently playing. If not, will print error to console.
+        public static void StopSoundEffect(Ocarina.SoundEffects sfxName)
+        {
+            if (InPlaySound.ContainsKey(sfxName))
+            {
+                SoundEffectInstance effectInstance = InPlaySound[sfxName];
+                effectInstance.Stop();
+                InPlaySound.Remove(sfxName);
+            }
+            else
+            {
+                Console.WriteLine("DEBUG: WINDWAKER_SOUND_SYSTEM: TRACK KILL FAILED: SONG NOT FOUND / WAS NOT BEING PLAYED.");
+            }
 
-
-        //    }
-        //    else
-        //    {
-        //        Console.WriteLine("DEBUG: OCARINA_SOUND_SYSTEM: TRACK KILL FAILED: EFFECT NOT FOUND / WAS NOT BEING PLAYED.");
-        //    }
-
-        //}
+        }
     }
 }

--- a/sprint0/Sound/WindWaker/WindWaker.cs
+++ b/sprint0/Sound/WindWaker/WindWaker.cs
@@ -14,10 +14,17 @@ namespace sprint0.Sound.Ocarina
      */
     public static class WindWaker
     {
-        public enum Songs { TITLE, OVERWORLD, DUNGEON, ENDING,
-          TRIFORCE_OBTAIN };
+        public enum Songs
+        {
+            TITLE, OVERWORLD, DUNGEON, ENDING,
+            TRIFORCE_OBTAIN
+        };
         private static IDictionary<Songs, WindWakerSongData> Library
             = new Dictionary<Songs, WindWakerSongData>();
+        private static IDictionary<WindWaker.Songs, SoundEffectInstance>
+           InPlaySound = new Dictionary<WindWaker.Songs, SoundEffectInstance>();
+        private static IDictionary<WindWaker.Songs, SoundEffectInstance>
+           InPauseSound = new Dictionary<WindWaker.Songs, SoundEffectInstance>();
 
         // Returns true or false if the track was loaded into the library.
         public static bool LoadSong(WindWaker.Songs songName, SoundEffect song, bool isLoopable = false)
@@ -44,33 +51,67 @@ namespace sprint0.Sound.Ocarina
                     songInstance.IsLooped = true;
                 }
                 songInstance.Play();
+                if (!InPlaySound.ContainsKey(songName))
+                {
+                    InPlaySound.Add(songName, songInstance);
+                }
 
 
             }
             else
             {
-                Console.WriteLine("DEBUG: OCARINA_SOUND_SYSTEM: PLAYBACK FAILED: EFFECT NOT FOUND.");
+                Console.WriteLine("DEBUG: WINDWAKER_SOUND_SYSTEM: PLAYBACK FAILED: SONG NOT FOUND.");
             }
         }
         // Stops the given track on the assumption that it was properly loaded into the system.
         // As well as is currently playing. If not, will print error to console.
         public static void StopSong(WindWaker.Songs songName)
         {
-
+            if (InPlaySound.ContainsKey(songName))
+            {
+                SoundEffectInstance songInstance = InPlaySound[songName];
+                songInstance.Stop();
+                InPlaySound.Remove(songName);
+            }
+            else
+            {
+                Console.WriteLine("DEBUG: WINDWAKER_SOUND_SYSTEM: TRACK KILL FAILED: SONG NOT FOUND / WAS NOT BEING PLAYED.");
+            }
         }
 
         // Pauses the given track on the assumption that it was properly loaded into the system.
         // As well as is currently playing. If not, will print error to console.
         public static void PauseSong(WindWaker.Songs songName)
         {
+            if (InPlaySound.ContainsKey(songName))
+            {
+                SoundEffectInstance songInstance = InPlaySound[songName];
+                songInstance.Pause();
+                InPauseSound.Add(songName, songInstance);
+                InPlaySound.Remove(songName);
 
+            }
+            else
+            {
+                Console.WriteLine("DEBUG: WINDWAKER_SOUND_SYSTEM: TRACK PAUSE FAILED: SONG NOT FOUND / WAS NOT BEING PLAYED.");
+            }
         }
 
-        // Restarts the given track on the assumption that it was properly loaded into the system.
-        // As well as is currently playing. If not, will print error to console.
-        public static void RestartSong(WindWaker.Songs songName)
+        // Resumes the given track on the assumption that it was properly loaded into the system.
+        // As well as is currently paused. If not, will print error to console.
+        public static void ResumeSong(WindWaker.Songs songName)
         {
+            if (InPauseSound.ContainsKey(songName))
+            {
+                SoundEffectInstance songInstance = InPauseSound[songName];
+                songInstance.Resume();
 
+            }
+            else
+            {
+                Console.WriteLine("DEBUG: WINDWAKER_SOUND_SYSTEM: TRACK RESUME FAILED: SONG NOT FOUND / WAS NOT PAUSED.");
+            }
         }
     }
+
 }


### PR DESCRIPTION
**WHAT CHANGED**
----

**SoundSystem**
* Loaded the rest of the Ocarina Sound Effects (from Game1) so now sound effects can be used anywhere throughout the game.
* Implemented StopSoundEffect(), StopSong(), PauseSong(), and ResumeSong()
* Added Sound Effect launches to occur at Link Item Usage, as well as Handled Collision Events (which means Sound is now dependent on a working collision system to an extent)

**ItemSystem**
* Added in a tick-counter for the Sword so that it will stop being drawn once the timer has ran out.
* Changed rotations of bow and sword so that they look "better" even if theyre still spawning at the wrong spot.

