### PR TITLE
Elemental Enemies: Ice Oktorok and Fire Bokoblin and Other Fixes

### DIFF
--- a/sprint0/Collision/CollisionHandler.cs
+++ b/sprint0/Collision/CollisionHandler.cs
@@ -153,6 +153,9 @@ namespace sprint0.Collision
             GameObjectDelegate BlazeImpactDelegate = new GameObjectDelegate(BlazeImpact);
             GameObjectDelegate BombImpactDelegate = new GameObjectDelegate(BombImpact);
             GameObjectDelegate GroundItemPickUpDelegate = new GameObjectDelegate(GenericGroundItemPickUp);
+            GameObjectDelegate MoveOktorokAndTakeDamageFromSwordDelegate = new GameObjectDelegate(MoveOktorokAndTakeDamageFromSword);
+            GameObjectDelegate MoveBokoblinAndTakeDamageFromSwordDelegate = new GameObjectDelegate(MoveBokoblinAndTakeDamageFromSword);
+
 
 
             // BOUNDARIES
@@ -288,10 +291,10 @@ namespace sprint0.Collision
             collisionTable.Rows.Add(new Object[] { "sprint0.Items.Bomb", "sprint0.Enemies.Dragon", BombImpactDelegate, MoveDragonAndTakeDamageDelegate });
             collisionTable.Rows.Add(new Object[] { "sprint0.Items.Bomb", "sprint0.LinkObj.Link", null, null });
 
-            collisionTable.Rows.Add(new Object[] { "sprint0.LinkSword.Sword", "sprint0.Enemies.Bokoblin", SwordImpactDelegate, MoveBokoblinAndTakeDamageDelegate });
-            collisionTable.Rows.Add(new Object[] { "sprint0.LinkSword.Sword", "sprint0.Enemies.Oktorok", SwordImpactDelegate, MoveOktorokAndTakeDamageDelegate });
+            collisionTable.Rows.Add(new Object[] { "sprint0.LinkSword.Sword", "sprint0.Enemies.Bokoblin", SwordImpactDelegate, MoveBokoblinAndTakeDamageFromSwordDelegate });
+            collisionTable.Rows.Add(new Object[] { "sprint0.LinkSword.Sword", "sprint0.Enemies.Oktorok", SwordImpactDelegate, MoveOktorokAndTakeDamageFromSwordDelegate });
             collisionTable.Rows.Add(new Object[] { "sprint0.LinkSword.Sword", "sprint0.Enemies.Skeleton", SwordImpactDelegate, MoveSkeletonAndTakeDamageDelegate });
-            collisionTable.Rows.Add(new Object[] { "sprint0.LinkSword.Sword", "sprint0.Enemies.Dragon", SwordImpactDelegate, MoveSkeletonAndTakeDamageDelegate });
+            collisionTable.Rows.Add(new Object[] { "sprint0.LinkSword.Sword", "sprint0.Enemies.Dragon", SwordImpactDelegate, MoveDragonAndTakeDamageDelegate });
 
             // COMBAT ON LINK COLLISIONS
             collisionTable.Rows.Add(new Object[] { "sprint0.LinkObj.Link", "sprint0.Enemies.Oktorok", MoveLinkAndTakeDamageDelegate, null });
@@ -570,6 +573,40 @@ namespace sprint0.Collision
             Ocarina.PlaySoundEffect(Ocarina.SoundEffects.ENEMY_HIT);
         }
 
+        private void MoveOktorokAndTakeDamageFromSword(CollisionDetector.CollisionType collisionType, IGameObject obj)
+        {
+            Oktorok enemy = (Oktorok)obj;
+            switch (collisionType)
+            {
+                case CollisionDetector.CollisionType.TOP:
+                    enemy.ChangeEnemyY(-35);
+                    break;
+                case CollisionDetector.CollisionType.BOTTOM:
+                    enemy.ChangeEnemyY(35);
+                    break;
+                case CollisionDetector.CollisionType.LEFT:
+                    enemy.ChangeEnemyX(-35);
+                    break;
+                case CollisionDetector.CollisionType.RIGHT:
+                    enemy.ChangeEnemyX(35);
+                    break;
+            }
+            
+            switch (Globals.LinkItemSystem.CurrentTunic)
+            {
+                case Globals.LinkTunic.FIRE:
+                    ((IElementalEnemy)enemy).TakeCriticalDamage();
+                    break;
+                case Globals.LinkTunic.ICE:
+                    ((IElementalEnemy)enemy).TakeMinimalDamage();
+                    break;
+                default:
+                    enemy.TakeDamage();
+                    break;
+            }
+            Ocarina.PlaySoundEffect(Ocarina.SoundEffects.ENEMY_HIT);
+        }
+
         private void MoveSkeleton(CollisionDetector.CollisionType collisionType, IGameObject obj)
         {
             Skeleton enemy = (Skeleton)obj;
@@ -654,6 +691,39 @@ namespace sprint0.Collision
                     break;
             }
             enemy.TakeDamage();
+            Ocarina.PlaySoundEffect(Ocarina.SoundEffects.ENEMY_HIT);
+        }
+
+        private void MoveBokoblinAndTakeDamageFromSword(CollisionDetector.CollisionType collisionType, IGameObject obj)
+        {
+            Bokoblin enemy = (Bokoblin)obj;
+            switch (collisionType)
+            {
+                case CollisionDetector.CollisionType.TOP:
+                    enemy.ChangeEnemyY(-50);
+                    break;
+                case CollisionDetector.CollisionType.BOTTOM:
+                    enemy.ChangeEnemyY(50);
+                    break;
+                case CollisionDetector.CollisionType.LEFT:
+                    enemy.ChangeEnemyX(-50);
+                    break;
+                case CollisionDetector.CollisionType.RIGHT:
+                    enemy.ChangeEnemyX(50);
+                    break;
+            }
+            switch (Globals.LinkItemSystem.CurrentTunic)
+            {
+                case Globals.LinkTunic.FIRE:
+                    ((IElementalEnemy)enemy).TakeMinimalDamage();
+                    break;
+                case Globals.LinkTunic.ICE:
+                    ((IElementalEnemy)enemy).TakeCriticalDamage();
+                    break;
+                default:
+                    enemy.TakeDamage();
+                    break;
+            }
             Ocarina.PlaySoundEffect(Ocarina.SoundEffects.ENEMY_HIT);
         }
 

--- a/sprint0/Enemies/Bokoblin.cs
+++ b/sprint0/Enemies/Bokoblin.cs
@@ -9,17 +9,19 @@ using Microsoft.Xna.Framework.Content;
 using Microsoft.Xna.Framework.Graphics;
 using sprint0;
 using sprint0.AnimatedSpriteFactory;
+using sprint0.HUDs;
 using sprint0.Items;
 using sprint0.Sound.Ocarina;
 
 namespace sprint0.Enemies
 {
-    public class Bokoblin : IEnemy
+    public class Bokoblin : IEnemy, IElementalEnemy
     {
         private Sprint0 Game;
         private SpriteFactory BokoblinFactory;
         private SpriteBatch SpriteBatch;
         private ISprite BokoSprite;
+        private Globals.EnemyElementType element;
         private int xPos;
         private int yPos;
         private int Height;
@@ -36,7 +38,7 @@ namespace sprint0.Enemies
         public Bokoblin(int x, int y, int roomId, SpriteFactory spriteFactory, SpriteFactory projectileFactory)
         {
             /* Subject to Change */
-            Health = 3;
+            Health = 4;
 
             xPos = x;
             yPos = y;
@@ -44,6 +46,8 @@ namespace sprint0.Enemies
             BokoblinFactory = spriteFactory;
             BokoSprite = BokoblinFactory.getAnimatedSprite("Down");
             Boomerang = new BokoblinBoomerang(projectileFactory);
+            element = Globals.EnemyElementType.NEUTRAL;
+
             Globals.GameObjectManager.addObject(Boomerang);
 
             /* Temporary Values */
@@ -197,6 +201,13 @@ namespace sprint0.Enemies
             BokoSprite.Update();
             Boomerang.Update();
 
+            if (Inventory.CurrentLinkLevel.Equals(Inventory.LinkLevel.HIGH)
+                /*|| Inventory.CurrentLinkLevel.Equals(Inventory.LinkLevel.HIGH) */)
+            // it shouldn't change once its set so idk if the above line is neccesary
+            {
+                element = Globals.EnemyElementType.FIRE;
+            }
+
             Random rnd = new Random();
             int direction = rnd.Next(4);
 
@@ -245,7 +256,7 @@ namespace sprint0.Enemies
                 }
             }
 
-            Health--;
+            Health = Health - 2;
             if (Health <= 0)
             {
                 BokoState = State.Dead;
@@ -282,5 +293,77 @@ namespace sprint0.Enemies
            yPos += change;
         }
         public String type() { return "Enemy"; }
+
+        public Globals.EnemyElementType EnemyElement()
+        {
+            return element;
+        }
+
+        public void TakeCriticalDamage()
+        {
+            // theres no such thing as crit damage if you have not been leveled up yet.
+            if (element.Equals(Globals.EnemyElementType.FIRE))
+            {
+                Console.WriteLine("Critical Hit!");
+                /* Placeholder Knockback animation */
+                for (int i = 0; i < 10; i++)
+                {
+                    switch (getDirection())
+                    {
+                        case 0:
+                            yPos--;
+                            break;
+                        case 1:
+                            xPos++;
+                            break;
+                        case 2:
+                            yPos++;
+                            break;
+                        case 3:
+                            xPos--;
+                            break;
+                    }
+                }
+
+                Health = Health - 3;
+                if (Health <= 0)
+                {
+                    BokoState = State.Dead;
+                }
+            }
+        }
+
+        public void TakeMinimalDamage()
+        {
+            // likewise theres no such thing as min damage if you have not been leveled up yet.
+            if (element.Equals(Globals.EnemyElementType.FIRE))
+            {
+                /* Placeholder Knockback animation */
+                for (int i = 0; i < 10; i++)
+                {
+                    switch (getDirection())
+                    {
+                        case 0:
+                            yPos--;
+                            break;
+                        case 1:
+                            xPos++;
+                            break;
+                        case 2:
+                            yPos++;
+                            break;
+                        case 3:
+                            xPos--;
+                            break;
+                    }
+                }
+
+                Health = Health - 1;
+                if (Health <= 0)
+                {
+                    BokoState = State.Dead;
+                }
+            }
+        }
     }
 }

--- a/sprint0/Enemies/Dragon.cs
+++ b/sprint0/Enemies/Dragon.cs
@@ -4,9 +4,11 @@ using System.Linq;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
 using System.Threading.Tasks;
+using System.Xml.Linq;
 using Microsoft.Xna.Framework.Graphics;
 using sprint0;
 using sprint0.AnimatedSpriteFactory;
+using sprint0.HUDs;
 using sprint0.Items;
 using sprint0.Sound.Ocarina;
 
@@ -31,7 +33,7 @@ namespace sprint0.Enemies
         public Dragon(int x, int y, int roomId, SpriteFactory spriteFactory, SpriteFactory projectileFactory)
         {
             /* Can be adjusted */
-            Health = 10;
+            Health = 12;
 
             xPos = x;
             yPos = y;
@@ -185,6 +187,21 @@ namespace sprint0.Enemies
             {
                 fireball.Update();
             }
+
+            /*
+             * Link's Level can only be increased, not decreased, 
+             * so this should be fine. We won't do this at the constructor
+             * level, since his health wont increase as Link plays the game.
+             */
+            if (Inventory.CurrentLinkLevel.Equals(Inventory.LinkLevel.MEDIUM))
+            {
+                Health = 14;
+            }
+            if (Inventory.CurrentLinkLevel.Equals(Inventory.LinkLevel.HIGH))
+            {
+                Health = 16;
+            }
+
 
             Random rnd = new Random();
             int direction = rnd.Next(4);

--- a/sprint0/Enemies/IElementalEnemy.cs
+++ b/sprint0/Enemies/IElementalEnemy.cs
@@ -1,0 +1,11 @@
+﻿using System;
+namespace sprint0.Enemies
+{
+	public interface IElementalEnemy
+	{
+		public Globals.EnemyElementType EnemyElement();
+		public void TakeCriticalDamage();
+		public void TakeMinimalDamage();
+	}
+}
+

--- a/sprint0/Enemies/Oktorok.cs
+++ b/sprint0/Enemies/Oktorok.cs
@@ -7,17 +7,19 @@ using System.Threading.Tasks;
 using Microsoft.Xna.Framework.Graphics;
 using sprint0;
 using sprint0.AnimatedSpriteFactory;
+using sprint0.HUDs;
 using sprint0.Items;
 using sprint0.Sound.Ocarina;
 
 namespace sprint0.Enemies
 {
-    public class Oktorok : IEnemy
+    public class Oktorok : IEnemy, IElementalEnemy
     {
         private Sprint0 Game;
         private SpriteFactory OktorokFactory;
         private SpriteBatch SpriteBatch;
         private ISprite OktoSprite;
+        private Globals.EnemyElementType element;
         private int xPos;
         private int yPos;
         private int Height;
@@ -34,7 +36,7 @@ namespace sprint0.Enemies
         public Oktorok(int x, int y, int roomId, SpriteFactory spriteFactory, SpriteFactory projectileFactory)
         {
             /* Subject to Change */
-            Health = 3;
+            Health = 4;
 
             xPos = x;
             yPos = y;
@@ -42,6 +44,7 @@ namespace sprint0.Enemies
             OktorokFactory = spriteFactory;
             OktoSprite = OktorokFactory.getAnimatedSprite("Down");
             Projectile = new OktorokBlaze(projectileFactory);
+            element = Globals.EnemyElementType.NEUTRAL;
             Globals.GameObjectManager.addObject(Projectile);
 
             /* Temporary Values */
@@ -188,6 +191,13 @@ namespace sprint0.Enemies
             OktoSprite.Update();
             Projectile.Update();
 
+            if (Inventory.CurrentLinkLevel.Equals(Inventory.LinkLevel.MEDIUM)
+                /*|| Inventory.CurrentLinkLevel.Equals(Inventory.LinkLevel.HIGH) */)
+            // it shouldn't change once its set so idk if the above line is neccesary
+            {
+                element = Globals.EnemyElementType.ICE;
+            }
+
             Random rnd = new Random();
             int direction = rnd.Next(4);
 
@@ -233,7 +243,7 @@ namespace sprint0.Enemies
                 }
             }
 
-            Health--;
+            Health = Health - 2;
             if (Health <= 0)
             {
                 OktoState = State.Dead;
@@ -269,5 +279,75 @@ namespace sprint0.Enemies
         }
         public String type() { return "Enemy"; }
 
+        public Globals.EnemyElementType EnemyElement()
+        {
+            return element;
+        }
+
+        public void TakeCriticalDamage()
+        {
+            // theres no such thing as crit damage if you have not been leveled up yet.
+            if (element.Equals(Globals.EnemyElementType.ICE))
+            {
+                /* Placeholder Knockback animation */
+                for (int i = 0; i < 10; i++)
+                {
+                    switch (getDirection())
+                    {
+                        case 0:
+                            yPos--;
+                            break;
+                        case 1:
+                            xPos++;
+                            break;
+                        case 2:
+                            yPos++;
+                            break;
+                        case 3:
+                            xPos--;
+                            break;
+                    }
+                }
+
+                Health = Health - 3;
+                if (Health <= 0)
+                {
+                    OktoState = State.Dead;
+                }
+            }
+        }
+
+        public void TakeMinimalDamage()
+        {
+            // likewise theres no such thing as min damage if you have not been leveled up yet.
+            if (element.Equals(Globals.EnemyElementType.ICE))
+            {
+                /* Placeholder Knockback animation */
+                for (int i = 0; i < 10; i++)
+                {
+                    switch (getDirection())
+                    {
+                        case 0:
+                            yPos--;
+                            break;
+                        case 1:
+                            xPos++;
+                            break;
+                        case 2:
+                            yPos++;
+                            break;
+                        case 3:
+                            xPos--;
+                            break;
+                    }
+                }
+
+                Health = Health - 1;
+                if (Health <= 0)
+                {
+                    OktoState = State.Dead;
+                }
+            }
+        }
     }
 }

--- a/sprint0/Enemies/Skeleton.cs
+++ b/sprint0/Enemies/Skeleton.cs
@@ -28,7 +28,7 @@ namespace sprint0.Enemies
         public Skeleton(int x, int y, int roomId, SpriteFactory spriteFactory)
         {
             /* Can be adjusted */
-            Health = 3;
+            Health = 4;
 
             xPos = x;
             yPos = y;

--- a/sprint0/Game1.cs
+++ b/sprint0/Game1.cs
@@ -438,6 +438,7 @@ namespace sprint0
             DragonObj.Update();
             heart.Update();
             CollisionIterator.Iterate(Globals.GameObjectManager.getList("drawables"));
+            Globals.GameObjectManager.deleteObjects();
             base.Update(gameTime);
         }
 

--- a/sprint0/Globals.cs
+++ b/sprint0/Globals.cs
@@ -20,6 +20,7 @@ namespace sprint0
 		public enum ItemSlots { SLOT_A, SLOT_B };
 		public enum ItemsInSlots { BOW, BETTER_BOW, BOOMERANG, BETTER_BOOMERANG, BLAZE, BOMB, SWORD, EMPTY};
 		public enum LinkTunic {GREEN, ICE, FIRE};
+		public enum EnemyElementType {NEUTRAL, ICE, FIRE};
     }
 }
 

--- a/sprint0/HUDs/Inventory.cs
+++ b/sprint0/HUDs/Inventory.cs
@@ -9,6 +9,16 @@ namespace sprint0.HUDs
 {
     public static class Inventory
     {
+        public enum LinkLevel
+        {
+            LOW, MEDIUM, HIGH
+        }
+
+        /* ELEMENTAL ENEMIES AND SCALING TESTING. REMOVE THIS LINE AND INIT
+         * THIS VALUE PROPERLY WHEN YOU GET TO IT.
+         */
+        
+        public static LinkLevel CurrentLinkLevel = LinkLevel.HIGH;
 
         //Checking on global for pause (!pause) or a boolean method to check if this is paused??
         //ENUM

--- a/sprint0/Items/linkSword/Sword.cs
+++ b/sprint0/Items/linkSword/Sword.cs
@@ -71,7 +71,7 @@ namespace sprint0.LinkSword
 
         public int height()
         {
-            return this.currentItemSprite.GetHeight();
+            return this.currentItemSprite.GetHeight() + 20;
         }
 
         public bool isDynamic()
@@ -142,7 +142,7 @@ namespace sprint0.LinkSword
 
         public int width()
         {
-            return this.currentItemSprite.GetWidth();
+            return this.currentItemSprite.GetWidth() + 20;
         }
 
         public int xPosition()


### PR DESCRIPTION
* Elemental Sword Collision Handling Updates 
* Sword Updates (Increasing Hitbox)
* Inventory (Link's Current Level is **hardcoded** to HIGH right now for the sake of testing.)
* Game1 (Link's Current Tunic is **hardcoded** to **ICE** right now for the sake of testing.)
* Enemy Health Adjustments
* Dragon now gets more health as his current level is increased.
* GOM Deletes Queued Objects in Game1.